### PR TITLE
Fix song title rendering in album list

### DIFF
--- a/src/CompletedAlbums.jsx
+++ b/src/CompletedAlbums.jsx
@@ -38,7 +38,7 @@ const CompletedAlbums = ({ theme, toggleTheme }) => {
                   rel="noopener noreferrer"
                   className="text-blue-500 dark:text-blue-400 hover:underline"
                 >
-                  {track.artist} - "{track.title}"
+                  {`${track.artist} - "${track.title}"`}
                 </a>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- fix track title interpolation so titles are displayed correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c786be51c832ebe12045d90ef14f4